### PR TITLE
SDK-961: Login link error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ matrix:
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_TRAVISCI=phpcs
-    - php: 5.3
-      env: WP_VERSION=latest
-      dist: precise
 
 before_install:
   - ./bin/checkout-sdk.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_TRAVISCI=phpcs
+    - php: 5.6
+      env: WP_VERSION=latest
 
 before_install:
   - ./bin/checkout-sdk.sh

--- a/tests/YotiTest.php
+++ b/tests/YotiTest.php
@@ -176,7 +176,7 @@ class YotiTest extends YotiTestBase
 
         $this->assertEmpty(YotiHelper::getFlash());
         $this->assertEmpty(YotiHelper::getYotiUserFromStore());
-        $this->assertIsArray(YotiHelper::getUserProfile($this->unlinkedUser->ID));
+        $this->assertTrue(is_array(YotiHelper::getUserProfile($this->unlinkedUser->ID)));
     }
 
     /**

--- a/tests/YotiTest.php
+++ b/tests/YotiTest.php
@@ -135,7 +135,7 @@ class YotiTest extends YotiTestBase
     /**
      * @covers ::yoti_login
      */
-    public function testLoginNoVerify()
+    public function testLoginNotVerified()
     {
         wp_create_nonce('yoti_verify');
         $_POST['yoti_nolink'] = '0';
@@ -152,6 +152,15 @@ class YotiTest extends YotiTestBase
         $this->assertEquals('message', $flash['type']);
         $this->assertEmpty(YotiHelper::getYotiUserFromStore());
         $this->assertFalse(YotiHelper::getUserProfile($this->unlinkedUser->ID));
+    }
+
+    /**
+     * @covers ::yoti_login
+     */
+    public function testLoginNoVerification()
+    {
+        Yoti::yoti_login('unlinked_user', $this->unlinkedUser);
+        $this->assertEmpty(YotiHelper::getFlash());
     }
 
     /**

--- a/yoti/class.yoti.php
+++ b/yoti/class.yoti.php
@@ -145,9 +145,13 @@ class Yoti
             return;
         }
 
-        // Verifiy the action.
-        $verified = !empty($_POST['yoti_verify']) && wp_verify_nonce($_POST['yoti_verify'], 'yoti_verify');
-        if (!$verified) {
+        // Return when the login form doesn't have yoti verification.
+        if (empty($_POST['yoti_verify'])) {
+            return;
+        }
+
+        // Verify the action.
+        if (!wp_verify_nonce($_POST['yoti_verify'], 'yoti_verify')) {
             YotiHelper::setFlash('Yoti profile could not be linked, please try again.');
         }
         else {
@@ -164,7 +168,6 @@ class Yoti
         }
 
         // Remove Yoti session
-        unset($_SESSION['yoti_nolink']);
         YotiHelper::clearYotiUserStore();
     }
 

--- a/yoti/class.yoti.php
+++ b/yoti/class.yoti.php
@@ -145,7 +145,7 @@ class Yoti
             return;
         }
 
-        // Return when the login form doesn't have yoti verification.
+        // Return when the login form doesn't have Yoti verification.
         if (empty($_POST['yoti_verify'])) {
             return;
         }


### PR DESCRIPTION
- Only display link error when the login form with Yoti verification fails
- Removed unneeded `unset($_SESSION['yoti_nolink']);`
- PHP `5.3` not supported and now fails on Travis due to https://core.trac.wordpress.org/ticket/47169 - replaced with PHP `5.6`