### PR TITLE
SDK-1020: Revert QR Type configuration

### DIFF
--- a/tests/YotiAdminTest.php
+++ b/tests/YotiAdminTest.php
@@ -62,21 +62,6 @@ class YotiAdminTest extends YotiTestBase
             $this->assertXpath($input_query, $html);
         }
 
-        // Check QR type field.
-        $this->assertXpath("//label[contains(text(),'QR Type')]", $html);
-        foreach (YotiAdmin::qrTypes() as $value => $label) {
-            $selected = $value == $this->config['yoti_qr_type'] ? "[@selected='selected']" : "[not(@selected)]";
-            $this->assertXpath(
-                sprintf(
-                    "//select[@name='yoti_qr_type']/option[@value='%s'][contains(text(),'%s')]%s",
-                    $value,
-                    $label,
-                    $selected
-                ),
-                $html
-            );
-        }
-
     }
 
 }

--- a/tests/YotiTestBase.php
+++ b/tests/YotiTestBase.php
@@ -20,7 +20,6 @@ class YotiTestBase extends WP_UnitTestCase
         'yoti_user_email' => 1,
         'yoti_age_verification' => 0,
         'yoti_company_name' => 'company_name',
-        'yoti_qr_type' => 'inline',
         'yoti_pem' => [
             'contents' => 'some-pem-contents',
         ],
@@ -148,7 +147,7 @@ class YotiTestBase extends WP_UnitTestCase
         $button_attributes = [
             sprintf("[@data-yoti-application-id='%s']", $this->config['yoti_app_id']),
             sprintf("[@data-yoti-scenario-id='%s']", $this->config['yoti_scenario_id']),
-            sprintf("[@data-yoti-type='%s']", $this->config['yoti_qr_type']),
+            "[@data-yoti-type='inline']",
             "[@data-size='small']",
         ];
         return "//div[@class='yoti-connect']/span" . implode('', $button_attributes);

--- a/yoti/YotiAdmin.php
+++ b/yoti/YotiAdmin.php
@@ -46,21 +46,6 @@ class YotiAdmin
     }
 
     /**
-     * List of QR Types.
-     *
-     * @return array
-     */
-    public static function qrTypes()
-    {
-        return [
-            'inline' => 'Inline',
-            'connect' => 'Connect Page',
-            'popout' => 'Popout',
-            'instant' => 'Instant',
-        ];
-    }
-
-    /**
      * options page for admin
      */
     private function options()

--- a/yoti/YotiAdmin.php
+++ b/yoti/YotiAdmin.php
@@ -106,7 +106,6 @@ class YotiAdmin
                 $data['yoti_only_existing'] = $this->postVar('yoti_only_existing');
                 $data['yoti_user_email'] = $this->postVar('yoti_user_email');
                 $data['yoti_age_verification'] = $this->postVar('yoti_age_verification');
-                $data['yoti_qr_type'] = $this->postVar('yoti_qr_type');
                 $pemFile = $this->filesVar('yoti_pem', $config['yoti_pem']);
 
                 // Validation
@@ -125,11 +124,6 @@ class YotiAdmin
                 elseif (!empty($pemFile['tmp_name']) && !openssl_get_privatekey(file_get_contents($pemFile['tmp_name'])))
                 {
                     $errors['yoti_pem'] = 'PEM file is invalid.';
-                }
-
-                if (!in_array($data['yoti_qr_type'], array_keys(YotiAdmin::qrTypes())))
-                {
-                    $errors['yoti_qr_type'] = 'QR type "' . $data['yoti_qr_type'] . '" is invalid. Allowed types: ' .  implode(', ', YotiAdmin::qrTypes());
                 }
             }
             catch (\Exception $e) {

--- a/yoti/YotiButton.php
+++ b/yoti/YotiButton.php
@@ -46,7 +46,6 @@ class YotiButton
             $is_linked = !empty(get_user_meta($currentUser->ID, 'yoti_user.identifier'));
         }
 
-        $qr_type = YotiHelper::getQrType();
         $message = YotiHelper::getFlash();
 
         // Build unlink URL.
@@ -55,7 +54,6 @@ class YotiButton
 
         $view = function () use (
             $is_linked,
-            $qr_type,
             $service_url,
             $qr_url,
             $message,

--- a/yoti/YotiHelper.php
+++ b/yoti/YotiHelper.php
@@ -682,29 +682,6 @@ class YotiHelper
     }
 
     /**
-     * Get QR Type.
-     *
-     * @return string
-     */
-    public static function getQrType()
-    {
-        $config = self::getConfig();
-
-        // Default value when the plugin is first enabled.
-        if (empty($config)) {
-            return 'inline';
-        }
-
-        // Default value when the QR type has not yet been specified.
-        if (empty($config['yoti_qr_type'])) {
-            return 'inline';
-        }
-
-        // The configured value.
-        return $config['yoti_qr_type'];
-    }
-
-    /**
      * Remove Yoti config option data from WordPress option table.
      */
     public static function deleteYotiConfigData()

--- a/yoti/readme.txt
+++ b/yoti/readme.txt
@@ -80,9 +80,8 @@ For FAQ please click [here.](https://yoti.zendesk.com/hc/en-us/categories/201129
 
 Here you can find the changes for each version:
 
-1.4.0
+1.3.2
 
-* Allow QR type to be configured
 * Display unlink button on profile when only Remember Me ID is shared
 
 1.3.1

--- a/yoti/readme.txt
+++ b/yoti/readme.txt
@@ -5,7 +5,7 @@ Tags: identity, verification, login, form, 2 factor, 2 step authentication, 2FA,
 Requires at least: 3.0.1
 Tested up to: 5.2
 Requires PHP: 5.6
-Stable tag: 1.4.0
+Stable tag: 1.3.2
 License: GNU v3
 License URI: https://www.gnu.org/licenses/gpl.txt
 

--- a/yoti/views/admin-options.php
+++ b/yoti/views/admin-options.php
@@ -4,9 +4,6 @@
  * @var string $updateMessage
  * @var array $errors
  */
-
-// Get the default QR type.
-$qrType = isset($data['yoti_qr_type']) ? $data['yoti_qr_type'] : YotiHelper::getQrType();
 ?>
 <div class="wrap">
     <h1>Yoti Settings</h1>
@@ -62,16 +59,6 @@ $qrType = isset($data['yoti_qr_type']) ? $data['yoti_qr_type'] : YotiHelper::get
               <td>
                   <input name="yoti_company_name" type="text" id="yoti_company_name" value="<?php esc_attr_e($data['yoti_company_name']); ?>" class="regular-text code" />
                   <p><code>Company Name</code> to replace WordPress wording in the warning message on the login form.</p>
-              </td>
-          </tr>
-          <tr>
-              <th scope="row"><label for="yoti_qr_type">QR Type</label></th>
-              <td>
-                  <select name="yoti_qr_type" id="yoti_qr_type" class="regular-text code">
-                  <?php foreach (YotiAdmin::qrTypes() as $key => $value) { ?>
-                    <option <?php selected($key == $qrType); ?> value="<?php esc_attr_e($key); ?>"><?php esc_html_e($value); ?></option>
-                  <?php } ?>
-                  </select>
               </td>
           </tr>
           <tr>

--- a/yoti/views/button.php
+++ b/yoti/views/button.php
@@ -20,7 +20,7 @@
         <span data-yoti-application-id="<?php esc_attr_e($config['yoti_app_id']); ?>"
             data-yoti-scenario-id="<?php esc_attr_e($config['yoti_scenario_id']); ?>"
             data-size="small"
-            <?php if($qr_type !== 'connect') { ?>data-yoti-type="<?php esc_html_e($qr_type); ?>"<?php } ?>
+            data-yoti-type="inline"
             ><?php esc_html_e($button_text); ?></span>
         <script>
             <?php if (!empty($qr_url)) { ?>_ybg.config.qr = <?php echo wp_json_encode($qr_url); ?>;<?php } ?>


### PR DESCRIPTION
This undoes QR configuration added in #43 (which hasn't been released).

We decided to remove the option to configure the QR type as we are set to change the default type shortly, which we would like to do in a non-breaking way.