### PR TITLE
SDK-31: Fix app.dockerfile

### DIFF
--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -12,11 +12,11 @@ fi
 RUN set -ex; \
         git clone -b ${BRANCH} https://github.com/getyoti/yoti-wordpress.git --single-branch /usr/src/yoti-wordpress; \
         echo "Finished cloning ${BRANCH}"; \
-	chown -R www-data:www-data /usr/src/yoti-wordpress; \
-       	cd /usr/src/yoti-wordpress; \
+        chown -R www-data:www-data /usr/src/yoti-wordpress; \
+        cd /usr/src/yoti-wordpress; \
         mkdir __sdk-sym; \
-        ./pack-plugin.sh; \
-   	echo "Finished packing the plugin"; \
+        ./bin/pack-plugin.sh; \
+        echo "Finished packing the plugin"; \
         mv ./${PLUGIN_PACKAGE_NAME} /usr/src/wordpress/wp-content/plugins; \
         cd /usr/src/wordpress/wp-content/plugins; \
         unzip ${PLUGIN_PACKAGE_NAME}; \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - wordpress-base
     build:
       context: ./
-      dockerfile: app.base.dockerfile
+      dockerfile: app.dockerfile
       args:
         BRANCH: "master"
     ports:


### PR DESCRIPTION
Fixing the `app.dockerfile` to use the relocated `./bin/pack-plugin.sh`, which changed in #44 

This can be tested running:
```
$ docker-compose build --no-cache --build-arg BRANCH=development wordpress
```

We are primary using `app.dev.dockerfile` for development and testing as it mounts the local working copy of the plugin, whereas `app.dockerfile` is used to build an image that contains the plugin code and can be distributed.
