### PR TITLE
SDK-803: Fix backwards compatibility

### DIFF
--- a/tests/YotiButtonTest.php
+++ b/tests/YotiButtonTest.php
@@ -15,12 +15,9 @@ class YotiButtonTest extends YotiTestBase
     {
         wp_set_current_user($this->unlinkedUser->ID);
 
-        ob_start();
-        YotiButton::render();
-
         $this->assertXpath(
             $this->getButtonXpath() . "[contains(text(), 'Link to Yoti')]",
-            ob_get_clean()
+            YotiButton::render()
         );
     }
 
@@ -29,12 +26,9 @@ class YotiButtonTest extends YotiTestBase
      */
     public function testButtonAnonymous()
     {
-        ob_start();
-        YotiButton::render();
-
         $this->assertXpath(
             $this->getButtonXpath() . "[contains(text(), 'Use Yoti')]",
-            ob_get_clean()
+            YotiButton::render()
         );
     }
 
@@ -43,9 +37,7 @@ class YotiButtonTest extends YotiTestBase
      */
     public function testButtonScript()
     {
-        ob_start();
-        YotiButton::render();
-        $html = ob_get_clean();
+        $html = YotiButton::render();
 
         $this->assertXpath("//script[contains(.,'_ybg.init();')]", $html);
         $this->assertXpath("//script[not(contains(.,'_ybg.config.qr'))]", $html);
@@ -59,9 +51,7 @@ class YotiButtonTest extends YotiTestBase
     {
         putenv('YOTI_CONNECT_BASE_URL=https://www.example.com/connect');
 
-        ob_start();
-        YotiButton::render();
-        $html = ob_get_clean();
+        $html = YotiButton::render();
 
         $this->assertXpath('//script[contains(.,"_ybg.init();")]', $html);
         $this->assertXpath("//script[contains(.,'_ybg.config.qr = \"https:\/\/www.example.com\/qr\/\";')]", $html);
@@ -75,9 +65,6 @@ class YotiButtonTest extends YotiTestBase
     {
         wp_set_current_user($this->linkedUser->ID);
 
-        ob_start();
-        YotiButton::render();
-
         $link_attributes = [
             "[@class='yoti-connect-button']",
             "[contains(@href,'/wp-login.php?yoti-select=1&action=unlink&redirect&yoti_verify=')]",
@@ -85,7 +72,7 @@ class YotiButtonTest extends YotiTestBase
 
         $this->assertXpath(
             '//a' . implode('', $link_attributes) . "[contains(text(), 'Unlink Yoti Account')]",
-            ob_get_clean()
+            YotiButton::render()
         );
     }
 

--- a/yoti/YotiButton.php
+++ b/yoti/YotiButton.php
@@ -17,8 +17,11 @@ class YotiButton
      *
      * @param null $redirect
      * @param bool $from_widget
+     * @param boolean $echo
+     *
+     * @return string|null
      */
-    public static function render($redirect = NULL, $from_widget = FALSE)
+    public static function render($redirect = NULL, $from_widget = FALSE, $echo = FALSE)
     {
         // No config? no button
         $config = YotiHelper::getConfig();
@@ -65,6 +68,12 @@ class YotiButton
         {
             require __DIR__ . '/views/button.php';
         };
+
+        if ($echo === FALSE) {
+            ob_start();
+            $view();
+            return ob_get_clean();
+        }
         $view();
     }
 }

--- a/yoti/views/profile.php
+++ b/yoti/views/profile.php
@@ -46,7 +46,7 @@ foreach ($dbProfile as $attrName => $value)
 <?php if ($displayButton) { ?>
     <tr>
         <th></th>
-        <td><?php YotiButton::render($_SERVER['REQUEST_URI']); ?></td>
+        <td><?php YotiButton::render($_SERVER['REQUEST_URI'], FALSE, TRUE); ?></td>
     </tr>
 <?php } ?>
 </table>

--- a/yoti/views/widget.php
+++ b/yoti/views/widget.php
@@ -16,7 +16,7 @@ if(!empty($title)){
 ?>
 <ul><li>
     <?php if (!empty($config['yoti_sdk_id']) && !empty($config['yoti_pem']['contents'])) { ?>
-        <?php YotiButton::render(NULL, TRUE); ?>
+        <?php YotiButton::render(NULL, TRUE, TRUE); ?>
     <?php } else { ?>
         <strong>Yoti not configured.</strong>
     <?php } ?>


### PR DESCRIPTION
Although it's unlikely this would be called directly, we shouldn't change this behaviour until a major release:
- Default button render to return string for backwards compatibility