### PR TITLE
SDK-1044: Add clientSdkId button configuration

### DIFF
--- a/tests/YotiButtonTest.php
+++ b/tests/YotiButtonTest.php
@@ -19,6 +19,7 @@ class YotiButtonTest extends YotiTestBase
 
         $config = $this->getButtonConfigFromMarkup($html);
         $this->assertEquals($config->button->label, 'Link to Yoti');
+        $this->assertEquals($config->clientSdkId, $this->config['yoti_sdk_id']);
         $this->assertEquals($config->scenarioId, $this->config['yoti_scenario_id']);
         $this->assertXpath("//div[@class='yoti-connect']/div[@id='{$config->domId}']", $html);
     }

--- a/yoti/assets/styles.css
+++ b/yoti/assets/styles.css
@@ -48,6 +48,10 @@
     padding: 3px 12px;
 }
 
+.yoti-connect .yoti-button {
+    height: 50px;
+}
+
 .wrap .pem-file {
     margin-bottom: 10px;
 }

--- a/yoti/views/button.php
+++ b/yoti/views/button.php
@@ -19,14 +19,14 @@
         <div id="<?php esc_attr_e($button_id); ?>" class="yoti-button"></div>
         <script>
             var yotiConfig = yotiConfig || { elements: [] };
-            yotiConfig.elements.push({
-                "domId": "<?php esc_attr_e($button_id); ?>",
-                "clientSdkId": "<?php esc_attr_e($config['yoti_sdk_id']); ?>",
-                "scenarioId": "<?php esc_attr_e($config['yoti_scenario_id']); ?>",
-                "button": {
-                    "label": "<?php esc_attr_e($button_text); ?>"
-                }
-            });
+            yotiConfig.elements.push(<?php echo json_encode(array(
+                'domId' => esc_attr($button_id),
+                'clientSdkId' => esc_attr($config['yoti_sdk_id']),
+                'scenarioId' => esc_attr($config['yoti_scenario_id']),
+                'button' => array(
+                    'label' => esc_attr($button_text),
+                ),
+            )); ?>);
         </script>
     <?php } elseif($from_widget) { ?>
         <strong>Yoti</strong> Linked

--- a/yoti/views/button.php
+++ b/yoti/views/button.php
@@ -21,6 +21,7 @@
             var yotiConfig = yotiConfig || { elements: [] };
             yotiConfig.elements.push({
                 "domId": "<?php esc_attr_e($button_id); ?>",
+                "clientSdkId": "<?php esc_attr_e($config['yoti_sdk_id']); ?>",
                 "scenarioId": "<?php esc_attr_e($config['yoti_scenario_id']); ?>",
                 "button": {
                     "label": "<?php esc_attr_e($button_text); ?>"


### PR DESCRIPTION
> Following #53 

### Added
- Newly required `clientSdkId` button configuration.

### Fixed
- Set button container height to _50px_ as per other plugins.
- Using `json_encode()` to encode the button configuration.