### PR TITLE
SDK-1082: Templates

### DIFF
--- a/yoti/views/activate-notice.php
+++ b/yoti/views/activate-notice.php
@@ -1,3 +1,4 @@
+<?php defined('ABSPATH') or die(); ?>
 <div class="notice notice-success is-dismissible">
   <p>
       <strong>Almost done</strong> - Complete Yoti

--- a/yoti/views/admin-options.php
+++ b/yoti/views/admin-options.php
@@ -1,4 +1,5 @@
 <?php
+defined('ABSPATH') or die();
 /**
  * @var array $data
  * @var string $updateMessage

--- a/yoti/views/button.php
+++ b/yoti/views/button.php
@@ -1,4 +1,5 @@
 <?php
+defined('ABSPATH') or die();
 /**
  * @var bool $is_linked
  * @var string $message

--- a/yoti/views/login-header.php
+++ b/yoti/views/login-header.php
@@ -1,4 +1,5 @@
 <?php
+defined('ABSPATH') or die();
 /**
  * @var string $companyName
  * @var bool $noLink

--- a/yoti/views/profile.php
+++ b/yoti/views/profile.php
@@ -1,4 +1,5 @@
 <?php
+defined('ABSPATH') or die();
 /**
  * @var array $dbProfile
  * @var bool $displayButton

--- a/yoti/views/widget.php
+++ b/yoti/views/widget.php
@@ -1,4 +1,5 @@
 <?php
+defined('ABSPATH') or die();
 /**
  * @var array $args
  * @var string $title


### PR DESCRIPTION
### Fixed
- Ensure WordPress has been bootstrapped before rendering templates

> Note: Checking `ABSPATH` is defined, similar to Joomla recommendation https://docs.joomla.org/Secure_coding_guidelines that checks `defined('_JEXEC')`