### PR TITLE
SDK-886: Use MariaDB client

### DIFF
--- a/docker/app.dev.dockerfile
+++ b/docker/app.dev.dockerfile
@@ -5,8 +5,8 @@ RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.extension.ini
 COPY ./docker/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
-# Install MySQL Client.
-RUN apt-get install -y mysql-client
+# Install MySQL/MariaDB Client.
+RUN apt-get install -y mariadb-client
 
 # Install PHP_CodeSniffer.
 RUN composer require dealerdirect/phpcodesniffer-composer-installer


### PR DESCRIPTION
### Fixed
- Installing `mariadb-client` (replaces `mysql-client`)

Merging to master as this has no release - I'll rebase development on master once merged

> Note: `mariadb-client` replaces `mysql-client` as `php` images now use Debian 10 (Buster) as its base image and Buster ships with _MariaDB_