### PR TITLE
SDK-1166: Set SDK version

### DIFF
--- a/bin/checkout-sdk.sh
+++ b/bin/checkout-sdk.sh
@@ -5,7 +5,7 @@
 
 NAME="yoti-for-wordpress-edge.zip"
 SDK_TAG=$1
-DEFAULT_SDK_TAG="2.0.0"
+DEFAULT_SDK_TAG="2.3.0"
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 PLUGIN_DIR="$BASE_DIR/yoti"
 

--- a/yoti/YotiHelper.php
+++ b/yoti/YotiHelper.php
@@ -52,6 +52,14 @@ class YotiHelper
      */
     const SDK_IDENTIFIER = 'WordPress';
 
+    /**
+     * Yoti WordPress SDK version.
+     */
+    const SDK_VERSION = '1.4.2';
+
+    /**
+     * @var array
+     */
     private $config;
 
     public function __construct()
@@ -91,6 +99,9 @@ class YotiHelper
                 !empty(getenv('YOTI_CONNECT_API')) ? getenv('YOTI_CONNECT_API') : YotiClient::DEFAULT_CONNECT_API,
                 self::SDK_IDENTIFIER
             );
+            $yotiClient->setSdkIdentifier(self::SDK_IDENTIFIER);
+            $yotiClient->setSdkVersion(self::SDK_VERSION);
+
             $activityDetails = $yotiClient->getActivityDetails($token);
             $profile = $activityDetails->getProfile();
         }

--- a/yoti/readme.txt
+++ b/yoti/readme.txt
@@ -5,7 +5,7 @@ Tags: identity, verification, login, form, 2 factor, 2 step authentication, 2FA,
 Requires at least: 3.0.1
 Tested up to: 5.2
 Requires PHP: 5.6
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GNU v3
 License URI: https://www.gnu.org/licenses/gpl.txt
 
@@ -79,6 +79,13 @@ For FAQ please click [here.](https://yoti.zendesk.com/hc/en-us/categories/201129
 == Changelog ==
 
 Here you can find the changes for each version:
+
+1.4.2
+
+Release Date - 9 September 2019
+
+* Default Curl request handler now verifies host and peer certificates. Only the unencrypted
+  parts of the receipt were at risk, as user profiles are always encrypted.
 
 1.4.1
 

--- a/yoti/readme.txt
+++ b/yoti/readme.txt
@@ -82,7 +82,7 @@ Here you can find the changes for each version:
 
 1.4.2
 
-Release Date - 9 September 2019
+Release Date - 10 September 2019
 
 * Default Curl request handler now verifies host and peer certificates. Only the unencrypted
   parts of the receipt were at risk, as user profiles are always encrypted.

--- a/yoti/yoti.php
+++ b/yoti/yoti.php
@@ -4,7 +4,7 @@
 Plugin Name: Yoti
 Plugin URI: https://wordpress.org/plugins/yoti/
 Description: Let Yoti users quickly register on your site.
-Version: 1.4.1
+Version: 1.4.2
 Author: Yoti SDK.
 Author URI: https://yoti.com
 */


### PR DESCRIPTION
### Changed
- Set plugin SDK version

### Security
- Default Curl request handler now verifies host and peer certificates. Only the unencrypted parts of the receipt were at risk, as user profiles are always encrypted